### PR TITLE
rest_api > Updating User considers also "updated_at"

### DIFF
--- a/rest_api/src/user/model.rs
+++ b/rest_api/src/user/model.rs
@@ -55,11 +55,12 @@ impl User {
     }
 
     pub fn update(id: Uuid, user: UserMessage) -> Result<Self, ApiError> {
+        use crate::schema::user::dsl::updated_at;
         let conn = db::connection()?;
 
         let user = diesel::update(user::table)
             .filter(user::id.eq(id))
-            .set(user)
+            .set((user_dto, updated_at.eq(Utc::now().naive_utc())))
             .get_result(&conn)?;
 
         Ok(user)


### PR DESCRIPTION
First of all, thanks for the extended and nicely written tutorial!

While playing with the result, I've noticed that `updated_at` column remains null after an update. This PR includes the missing part. Tested locally and it works.